### PR TITLE
Enhance comments for `if !n.wildChild` condition in getValue

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -465,7 +465,7 @@ walk: // Outer loop for walking the tree
 
 				if !n.wildChild {
 					// If the path at the end of the loop is not equal to '/' and the current node has no child nodes
-					// the current node needs to roll back to last valid skippedNode
+					// that matche the path, the current node needs to roll back to last valid skippedNode.
 					if path != "/" {
 						for length := len(*skippedNodes); length > 0; length-- {
 							skippedNode := (*skippedNodes)[length-1]


### PR DESCRIPTION
Refactor comments in the getValue function to accurately describe the rollback logic.

Previously, the comments in the `if !n.wildChild` branch incorrectly stated that the current node had no child nodes. In reality, it only lacks wildcard child nodes and may still have non-wildcard children that did not match the remaining path. The updated comments clarify that the rollback occurs when the remaining path is not '/' and no child nodes matched the path, and there are no wildcard children to handle the path.

This change improves code readability and helps future developers understand the routing logic more accurately.

- With pull requests:
  - Open your pull request against `master`
  - Your pull request should have no more than two commits, if not you should squash them.
  - It should pass all tests in the available continuous integration systems such as GitHub Actions.
  - You should add/modify tests to cover your proposed code changes.
  - If your pull request contains a new feature, please document it on the README.

